### PR TITLE
Remove redundant http(s): from URLs 

### DIFF
--- a/lib/middleman-google-analytics/extension.rb
+++ b/lib/middleman-google-analytics/extension.rb
@@ -32,7 +32,7 @@ module Middleman
   #{gaq.map! { |x| "_gaq.push(#{x});" }.join("\n  ")}
   (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/#{ga}.js';
+    ga.src = ('https:' == document.location.protocol ? '//ssl' : '//www') + '.google-analytics.com/#{ga}.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 //]]>


### PR DESCRIPTION
See http://stackoverflow.com/questions/743247/types-of-urls
