### PR TITLE
Fix pageview event for Universal Analytics

### DIFF
--- a/features/universal.feature
+++ b/features/universal.feature
@@ -22,7 +22,7 @@ Feature: Google Analytics universal tag helper
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
         ga('create', 'UA-123456-78', 'auto');
-        ga('pageview');
+        ga('send', 'pageview');
       </script>
       """
 
@@ -48,7 +48,7 @@ Feature: Google Analytics universal tag helper
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
         ga('create', 'UA-123456-78', 'example.com');
-        ga('pageview');
+        ga('send', 'pageview');
       </script>
       """
 
@@ -74,7 +74,7 @@ Feature: Google Analytics universal tag helper
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
         ga('create', 'UA-123456-78', 'example.com', {'allowLinker': true});
-        ga('pageview');
+        ga('send', 'pageview');
       </script>
       """
 
@@ -101,7 +101,7 @@ Feature: Google Analytics universal tag helper
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
         ga('create', 'UA-123456-78', 'auto');
         ga('set', 'anonymizeIp', true);
-        ga('pageview');
+        ga('send', 'pageview');
       </script>
       """
   Scenario: Full options
@@ -127,6 +127,6 @@ Feature: Google Analytics universal tag helper
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
         ga('create', 'UA-123456-78', 'example.com', {'allowLinker': true});
         ga('set', 'anonymizeIp', true);
-        ga('pageview');
+        ga('send', 'pageview');
       </script>
       """

--- a/lib/middleman-google-analytics/extension.rb
+++ b/lib/middleman-google-analytics/extension.rb
@@ -59,7 +59,7 @@ module Middleman
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
   ga('create', '#{ tracking_id }', '#{ domain_name || 'auto' }'#{ options.allow_linker ? ", {'allowLinker': true}" : '' });#{
     options.anonymize_ip ? "\n  ga('set', 'anonymizeIp', true);" : '' }
-  ga('pageview');
+  ga('send', 'pageview');
 </script>}
         end
       end


### PR DESCRIPTION
The "pageview" event is not properly sent using the new Universal Analytics code.

Therefore, switching to the new code will likely result in having no statistics available in Google Analytics.

Not a good thing not to have. ;)
