### PR TITLE
Fix conflicting version of uglifier

### DIFF
--- a/middleman-google-analytics.gemspec
+++ b/middleman-google-analytics.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
   s.add_dependency("middleman-core", ["~> 3.2"])
-  s.add_dependency("uglifier", ["~> 2.5"])
+  s.add_dependency("uglifier", ["~> 2.4.0"])
 end


### PR DESCRIPTION
Specified uglifier version is conflicting with middleman's dependency: https://github.com/middleman/middleman/blob/v3.2.2/middleman/middleman.gemspec
