### PR TITLE
Clarify difference between Google Analytics tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ keeps your config in `config.rb`, where it belongs.
   # Universal Analytics
   <%= google_analytics_universal_tag %>
   ```
+  
+  NOTE: [The Universal Analytics tag is the new operating standard for the Google Analytics tracking tag.][1]
+  
+  [1]: https://support.google.com/tagmanager/answer/6107124?hl=en
 
 ## Configuration
 


### PR DESCRIPTION
Reason for Change:
* I wasn't sure what the difference between "Google Analytics" and "Google Universal Analytics" was.

Change:
* Clarify that Universal Analytics is the preferred tag structure and provide an explanatory link.