### PR TITLE
Implement support for Google Optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ activate :google_analytics do |ga|
   # Enhanced Link Attribution (default = false)
   ga.enhanced_link_attribution = false
 
+  # Container ID for Google Optimize (A/B Testing)
+  ga.optimize = 'GTM-123456'
+
   # Log detail messages to the console (default = false)
   ga.debug = false
 
@@ -84,6 +87,7 @@ activate :google_analytics do |ga|
 
   # Output style - :html includes <script> tag (default = :html)
   ga.output = :js
+
 end
 ```
 

--- a/features/google_analytics.feature
+++ b/features/google_analytics.feature
@@ -142,6 +142,22 @@ Feature: Google Analytics tag helper
       ga('send', 'pageview');
       """
 
+  Scenario: Test Google Optimize plugin
+    Given the Server is running at "optimize"
+    When I go to "/google-analytics.html"
+    Then I should see:
+      """
+      <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        ga('create', 'UA-123456-78', 'auto');
+        ga('require', 'GTM-123456');
+        ga('send', 'pageview');
+      </script>
+      """
+
   Scenario: Test implementation without sending hits
     Given the Server is running at "test-app"
     When I go to "/google-analytics.html"

--- a/fixtures/optimize/config.rb
+++ b/fixtures/optimize/config.rb
@@ -1,0 +1,4 @@
+activate :google_analytics do |ga|
+  ga.tracking_id = 'UA-123456-78'
+  ga.optimize = 'GTM-123456'
+end

--- a/fixtures/optimize/source/google-analytics.html.erb
+++ b/fixtures/optimize/source/google-analytics.html.erb
@@ -1,0 +1,1 @@
+<%= google_analytics_tag %>

--- a/lib/middleman-google-analytics/analytics.js.erb
+++ b/lib/middleman-google-analytics/analytics.js.erb
@@ -16,6 +16,7 @@
   ga << "ga('set', 'sendHitTask', null);" if @options.test
   ga << "ga('set', 'anonymizeIp', true);" if @options.anonymize_ip
   ga << "ga('require', 'linkid');" if @options.enhanced_link_attribution
+  ga << "ga('require', '#{@options.optimize}');" if @options.optimize
   ga << "ga('send', 'pageview');"
 %>
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/lib/middleman-google-analytics/extension.rb
+++ b/lib/middleman-google-analytics/extension.rb
@@ -8,6 +8,7 @@ module Middleman
     option :domain_name, nil, 'Tracking across a domain and its subdomains'
     option :allow_linker, false, 'Tracking across multiple domains and subdomains'
     option :enhanced_link_attribution, false, 'Enhanced Link Attribution'
+    option :optimize, nil, 'Container ID'
     option :disable, false, 'Disable extension'
     option :debug, false, 'Log detail messages to the console'
     option :debug_trace, false, 'Trace debugging will output more verbose information to the console'


### PR DESCRIPTION
Support for Google Optimize (https://optimize.google.com/) which is implemented as a Google Analytics plugin. 

Implementation simply requires the addition of a container to the Google Analytics code. The corresponding tests have also been included in this pull request. Thanks!

```js
ga('require', 'GTM-123456');
```